### PR TITLE
fix: do not strcat() to an uninitialized buffer. rather strcpy() to it.

### DIFF
--- a/src/announce.c
+++ b/src/announce.c
@@ -87,7 +87,7 @@ int main(int argc, char *argv[]) {
 
     // readablename stays without ".local"
     char readablename[100 + 6];
-    strcat(readablename, hostname);
+    strcpy(readablename, hostname);
     printf("-->%s\n", readablename);
 
     // will not work if the hostname doesn't end in .local


### PR DESCRIPTION
When trying announce on my OpenWRT installation, I noticed it prepending garbage characters to my device's hostname. This is probably the same bug as described in #8.

The reason is that the name gets strcat()ed to an uninitialized buffer when storing the "readablename" version of it. Since this buffer is stack-allocated, it will typically contain garbage data, so the actual hostname gets appended wherever the first random 0-byte happens to be.

Since "readablename" and "hostname" are both used during service registration, all services fail to resolve if those two names do not match. Thus, this isn't just a cosmetic issue, but an app-breaking one.

The fix is to replace the strcat() with a strcpy() – Please note that strncpy() is not needed in this case, since the length of the source string is already limited by the gethostname() call.
